### PR TITLE
SAML-Toolkits update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
         ruby-version: [2.1.9, 2.2.10, 2.3.8, 2.4.6, 2.5.8, 2.6.6, 2.7.2, 3.0.1, '3.1', jruby-9.1.17.0, jruby-9.2.17.0, truffleruby]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Build Status](https://github.com/onelogin/ruby-saml/actions/workflows/test.yml/badge.svg?query=branch%3Amaster)](https://github.com/onelogin/ruby-saml/actions/workflows/test.yml?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/onelogin/ruby-saml/badge.svg?branch=master)](https://coveralls.io/r/onelogin/ruby-saml?branch=master)
 
-## **Notice:** This project is currently not under active development, please see [#640](https://github.com/onelogin/ruby-saml/issues/640) for more information.
-
 Ruby SAML minor and tiny versions may introduce breaking changes. Please read
 [UPGRADING.md](UPGRADING.md) for guidance on upgrading to new Ruby SAML versions.
 
@@ -16,7 +14,7 @@ requests from identity providers.
 SAML authorization is a two step process and you are expected to implement support for both.
 
 We created a demo project for Rails 4 that uses the latest version of this library:
-[ruby-saml-example](https://github.com/onelogin/ruby-saml-example)
+[ruby-saml-example](https://github.com/saml-toolkit/ruby-saml-example)
 
 ### Supported Ruby Versions
 
@@ -54,8 +52,7 @@ In addition, the following may work but are untested:
 ## Security Guidelines
 
 If you believe you have discovered a security vulnerability in this gem, please report it
-at https://www.onelogin.com/security with a description. We follow responsible disclosure
-guidelines, and will work with you to quickly find a resolution.
+as an issue
 
 ### Security Warning
 
@@ -89,7 +86,7 @@ Using `Gemfile`
 gem 'ruby-saml', '~> 1.11.0'
 
 # or track master for bleeding-edge
-gem 'ruby-saml', :github => 'onelogin/ruby-saml'
+gem 'ruby-saml', :github => 'saml-toolkit/ruby-saml'
 ```
 
 Using RubyGems
@@ -101,13 +98,13 @@ gem install ruby-saml
 You may require the entire Ruby SAML gem:
 
 ```ruby
-require 'onelogin/ruby-saml'
+require 'saml-toolkit/ruby-saml'
 ```
 
 or just the required components individually:
 
 ```ruby
-require 'onelogin/ruby-saml/authrequest'
+require 'saml-toolkit/ruby-saml/authrequest'
 ```
 
 ### Installation on Ruby 1.8.7

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.version = OneLogin::RubySaml::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = ["SAML Toolkit"]
   s.date = Time.now.strftime("%Y-%m-%d")
   s.description = %q{SAML toolkit for Ruby on Rails}
   s.license = 'MIT'

--- a/ruby-saml.gemspec
+++ b/ruby-saml.gemspec
@@ -6,17 +6,15 @@ Gem::Specification.new do |s|
   s.version = OneLogin::RubySaml::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["OneLogin LLC"]
   s.date = Time.now.strftime("%Y-%m-%d")
   s.description = %q{SAML toolkit for Ruby on Rails}
-  s.email = %q{support@onelogin.com}
   s.license = 'MIT'
   s.extra_rdoc_files = [
     "LICENSE",
     "README.md"
   ]
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  s.homepage = %q{https://github.com/onelogin/ruby-saml}
+  s.homepage = %q{https://github.com/saml-toolkit/ruby-saml}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}


### PR DESCRIPTION
Updates with latest version of ruby-saml, now managed by SAML-Toolkits instead of OneLogin. This is preparation for a [pull request to merge this fork](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/department-of-veterans-affairs/va.gov-team/50385) into the base repository.